### PR TITLE
Allow specifying parameters for BeautifulSoup

### DIFF
--- a/beautifulscraper/__init__.py
+++ b/beautifulscraper/__init__.py
@@ -137,7 +137,7 @@ class BeautifulScraper(object):
             raise ValueError("You called this method wrong, and I can't remove the cookies you think " \
                     "you are trying to tell me to remove.  Read `pydoc beautifulscraper.BeautifulScraper.remove_cookie`")
 
-    def go(self, url, data = None):
+    def go(self, url, data = None, **kwargs):
         """Makes a request to url.  It will be a GET request unless you specify data, in
         which case it will be a POST request with data as a payload.  The any headers in
         self.headers will be a part of the request.  Any cookies that the CookieJar decides
@@ -170,7 +170,7 @@ class BeautifulScraper(object):
 
         # remember for posteraity and return the parsed response
         self._last_request = request
-        return BeautifulSoup(response.read())
+        return BeautifulSoup(response.read(), **kwargs)
 
 
     class HTTPNoRedirectHandler(urllib2.HTTPRedirectHandler):


### PR DESCRIPTION
BeautifulSoup `__init__()` allows for specifying different HTML parser (like `lxml`) or a `SoupStrainer` instance to parse only part of the whole document. See http://www.crummy.com/software/BeautifulSoup/bs4/doc/#soupstrainer for an example. 

Beautifulscraper could allow specifying these parameters in its convenient go() method for better flexibility. I suggest simply adding `**kwargs` to make Beautifulscraper independent of changes in BeautifulSoup `__init__()` API.