### PR TITLE
Added parser argument

### DIFF
--- a/beautifulscraper/__init__.py
+++ b/beautifulscraper/__init__.py
@@ -137,7 +137,7 @@ class BeautifulScraper(object):
             raise ValueError("You called this method wrong, and I can't remove the cookies you think " \
                     "you are trying to tell me to remove.  Read `pydoc beautifulscraper.BeautifulScraper.remove_cookie`")
 
-    def go(self, url, data = None, **kwargs):
+    def go(self, url, parser = "html.parser", data = None, **kwargs):
         """Makes a request to url.  It will be a GET request unless you specify data, in
         which case it will be a POST request with data as a payload.  The any headers in
         self.headers will be a part of the request.  Any cookies that the CookieJar decides
@@ -172,7 +172,7 @@ class BeautifulScraper(object):
 
         # remember for posteraity and return the parsed response
         self._last_request = request
-        return BeautifulSoup(response.read(), **kwargs)
+        return BeautifulSoup(response.read(), parser, **kwargs)
 
 
     class HTTPNoRedirectHandler(urllib2.HTTPRedirectHandler):


### PR DESCRIPTION
1. To get rid of BeautifulSoup's default warning:

```python
UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

BeautifulSoup([your markup])

to this:

BeautifulSoup([your markup], "html.parser")

markup_type=markup_type))

This could be fixed by specifying parser in dependencies and setting it in BS call, like so:
soup = BeautifulSoup(content, "html.parser")
```
2. To allow for other parsers (HTML5, xml, ...) to being passed.